### PR TITLE
cleanup maps on exit

### DIFF
--- a/tetris.bt
+++ b/tetris.bt
@@ -226,3 +226,8 @@ interval:ms:99
   }
 }
 
+END
+{
+  clear(@B); clear(@C); clear(@K); clear(@P);
+  clear(@Z); clear(@e); clear(@h); clear(@t);
+}


### PR DESCRIPTION
This avoids printing all the map contents on Ctrl-C.