### PR TITLE
Remove redundant include

### DIFF
--- a/tetris.bt
+++ b/tetris.bt
@@ -7,8 +7,6 @@
 // General Public License (GPL); either version 2, or (at your option) any
 // later version.
 
-#include <linux/tty.h>
-
 kprobe:pty_write // (struct tty_struct *tty, const unsigned char *buf, int c)
 / arg2 == 1 /
 {


### PR DESCRIPTION
It's not used as far as I can tell and it wasn't loading correctly on my system. Removing it made tetris work for me.