### PR TITLE
Support running tetris in vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.pyc
 __pycache__/
 .mypy_cache/
+.vagrant
+*.log

--- a/README.md
+++ b/README.md
@@ -10,9 +10,31 @@ This is the ported version of [tetris.spt](https://github.com/mhiramat/stapgames
 - [bpftrace](https://github.com/iovisor/bpftrace) master branch version
 
 ## How to run
+
 - `./run.sh`
 
+### In Vagrant
+
+If you do not readily have access to a recent linux kernel and bpftrace, you can try the included Vagrant file which launches ubuntu eoan so you can still play tetris!
+
+
+Download vagrant from https://www.vagrantup.com/downloads.html, and make sure you have either VMWare or [Virtualbox 6.0 installed](https://www.virtualbox.org/wiki/Download_Old_Builds_6_0).
+
+Install both, then run:
+
+```
+vagrant plugin install vagrant-vbguest
+vagrant up
+```
+
+You can then run tetris with:
+
+```
+vagrant ssh -c "cd /vagrant/ && ./run.sh"
+```
+
 ## FAQ
+
 ### Q. Why is Linux 5.3+ required?
 Otherwise the BPF program will be rejected due to the maximum instruction limit (see [this commit](https://github.com/torvalds/linux/commit/c04c0d2b968ac45d6ef020316808ef6c82325a82).)
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Vagrant.configure('2') do |config|
+  config.vm.box = 'ubuntu/eoan64'
+  config.vm.provider 'virtualbox' do |v|
+    # Work around https://bugs.launchpad.net/cloud-images/+bug/1829625
+    v.customize ["modifyvm", :id, "--uart1", "0x3F8", "4"]
+    v.customize ["modifyvm", :id, "--uartmode1", "file", "./ttyS0.log"]
+  end
+  config.vm.provision 'shell',
+                      inline: '/bin/bash /vagrant/vagrant/provision.sh'
+
+  config.vm.provision 'shell', inline: 'echo "Vagrant is now provisioned - run \"vagrant ssh\" to access the vm"'
+end

--- a/run-in-vagrant.sh
+++ b/run-in-vagrant.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+vagrant ssh -c "cd /vagrant/ && ./run.sh"

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -x
+
+sudo apt-get update && apt-get install -y unzip
+
+wget https://github.com/dalehamel/bpftrace/suites/395704994/artifacts/1069051 -O bpftrace.zip
+unzip bpftrace.zip
+
+sudo mv bpftrace*/bpftrace /usr/bin/bpftrace
+sudo chmod +x /usr/bin/bpftrace
+sudo chmod +s /usr/bin/bpftrace


### PR DESCRIPTION
Since most folks don't have new kernels, this is a great way to be able to show off this awesome script that @mmisono ported, by making it a little easier to get access to a newer kernel.

A lot of folks with macbooks may already have a vagrant setup, and if not both vagrant and virtualbox are free.

This allows for anyone to install and run an ubuntu eoan image with a 5.3+ kernel, and downloads a glibc-linked bpftrace that they can use to run tetris. Should be able to get up and running in just a few minutes!

Right now this downloads from my own github actions build, but it can eventually just come from a bpftrace release artifact once bpftrace #1041 is merged and is publishing these artifacts.